### PR TITLE
Implement Focus Quest API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,27 +1,5 @@
-from app.models import FocusSession
-from app.database import Base, engine, SessionLocal
-import datetime
+from fastapi import FastAPI
+from app.routes import focus_routes
 
-# 1. Create tables (kalau belum ada)
-Base.metadata.create_all(bind=engine)
-
-# 2. Setup session
-db = SessionLocal()
-
-# 3. Coba insert data FocusSession (dummy data)
-new_session = FocusSession(
-    user_id=1,
-    start_time=datetime.datetime(2025, 3, 21, 10, 0, 0),
-    end_time=datetime.datetime(2025, 3, 21, 11, 0, 0),
-    duration_minutes=60.0,
-    description="Testing Session"
-)
-db.add(new_session)
-db.commit()
-
-print("Database & Model setup berhasil!")
-
-# 4. Optional: Query & print data
-sessions = db.query(FocusSession).all()
-for session in sessions:
-    print(session)
+app = FastAPI()
+app.include_router(focus_routes.router)

--- a/app/routes/focus_routes.py
+++ b/app/routes/focus_routes.py
@@ -1,0 +1,31 @@
+from typing import List
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+from app.models.focus_models import FocusSession
+from app.schemas.focus_schema import FocusSessionCreate, FocusSessionRead
+
+router = APIRouter(prefix="/focus", tags=["focus quest"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("/sessions", response_model=FocusSessionRead)
+def create_focus_session(session: FocusSessionCreate, db: Session = Depends(get_db)):
+    db_session = FocusSession(**session.dict())
+    db.add(db_session)
+    db.commit()
+    db.refresh(db_session)
+    return db_session
+
+
+@router.get("/sessions", response_model=List[FocusSessionRead])
+def read_focus_sessions(db: Session = Depends(get_db)):
+    return db.query(FocusSession).all()

--- a/app/schemas/focus_schema.py
+++ b/app/schemas/focus_schema.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
+
+
+class FocusSessionBase(BaseModel):
+    user_id: int
+    start_time: datetime
+    end_time: Optional[datetime] = None
+    duration_minutes: Optional[float] = None
+    description: Optional[str] = None
+
+
+class FocusSessionCreate(FocusSessionBase):
+    pass
+
+
+class FocusSessionRead(FocusSessionBase):
+    id: int
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- build GET and POST endpoints for Focus Quest feature
- define Pydantic schemas for FocusSession
- simplify `app/main.py` to load router

## Testing
- `python -m py_compile app/main.py app/routes/focus_routes.py app/schemas/focus_schema.py`
- `python test_models.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6842e15639a0832ebab3665d63c32add