### PR TITLE
Add Express backend scaffold with healthcheck

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+# Server configuration
+PORT=3001
+NODE_ENV=development

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,27 @@
+# Backend Server
+
+Backend Express server for ANTYO-Focus.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy `.env.example` to `.env` if you want to override defaults (e.g., `PORT`).
+3. Start the server:
+   ```bash
+   npm start
+   ```
+
+## Development
+
+Run with automatic reloads (requires `nodemon` from devDependencies):
+
+```bash
+npm run dev
+```
+
+## Healthcheck
+
+A healthcheck route is available at `GET /api/health` and returns a simple status payload.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "Backend server for ANTYO-Focus",
+  "main": "src/index.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.7"
+  }
+}

--- a/backend/src/config/config.js
+++ b/backend/src/config/config.js
@@ -1,0 +1,10 @@
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const config = {
+  port: process.env.PORT || 3001,
+  nodeEnv: process.env.NODE_ENV || 'development'
+};
+
+module.exports = config;

--- a/backend/src/controllers/healthController.js
+++ b/backend/src/controllers/healthController.js
@@ -1,0 +1,10 @@
+const healthService = require('../services/healthService');
+
+const getHealth = (_req, res) => {
+  const status = healthService.getHealthStatus();
+  return res.json(status);
+};
+
+module.exports = {
+  getHealth
+};

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const config = require('./config/config');
+const routes = require('./routes');
+
+const app = express();
+
+app.use(express.json());
+app.use('/api', routes);
+
+app.listen(config.port, () => {
+  console.log(`Server running in ${config.nodeEnv} mode on port ${config.port}`);
+});

--- a/backend/src/repositories/healthRepository.js
+++ b/backend/src/repositories/healthRepository.js
@@ -1,0 +1,9 @@
+const fetchStatus = () => ({
+  status: 'ok',
+  uptime: process.uptime(),
+  timestamp: new Date().toISOString()
+});
+
+module.exports = {
+  fetchStatus
+};

--- a/backend/src/routes/health.routes.js
+++ b/backend/src/routes/health.routes.js
@@ -1,0 +1,8 @@
+const { Router } = require('express');
+const healthController = require('../controllers/healthController');
+
+const router = Router();
+
+router.get('/', healthController.getHealth);
+
+module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -1,0 +1,11 @@
+const { Router } = require('express');
+const healthRoutes = require('./health.routes');
+
+const router = Router();
+
+router.use('/health', healthRoutes);
+router.get('/', (_req, res) => {
+  res.json({ message: 'API is running' });
+});
+
+module.exports = router;

--- a/backend/src/services/healthService.js
+++ b/backend/src/services/healthService.js
@@ -1,0 +1,7 @@
+const healthRepository = require('../repositories/healthRepository');
+
+const getHealthStatus = () => healthRepository.fetchStatus();
+
+module.exports = {
+  getHealthStatus
+};


### PR DESCRIPTION
## Summary
- scaffold backend folder structure with Express entrypoint and configuration loader
- add layered healthcheck route using controllers, services, and repositories
- document backend setup with README and environment example

## Testing
- npm install express dotenv --registry=https://registry.npmjs.org (fails: 403 Forbidden)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fca248990832ea4d3e7e8dcbaf0e0)