### PR TITLE
Add task CRUD service, routes, and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "node --test",
     "changelog": "standard-version"
   },
   "dependencies": {

--- a/src/__tests__/taskController.test.js
+++ b/src/__tests__/taskController.test.js
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createApp } from '../app.js';
+import { resetTasks } from '../services/taskService.js';
+
+test('task routes handle lifecycle with validation and errors', async () => {
+  resetTasks();
+  const app = createApp();
+
+  const createResponse = await app.handle({
+    method: 'POST',
+    path: '/tasks',
+    body: { title: 'Implement API', description: 'Wire controllers' },
+  });
+
+  assert.equal(createResponse.statusCode, 201);
+  assert.ok(createResponse.body.id);
+
+  const listResponse = await app.handle({ method: 'GET', path: '/tasks' });
+  assert.equal(listResponse.statusCode, 200);
+  assert.equal(listResponse.body.length, 1);
+
+  const taskId = createResponse.body.id;
+  const updateResponse = await app.handle({
+    method: 'PATCH',
+    path: `/tasks/${taskId}`,
+    body: { status: 'done' },
+  });
+  assert.equal(updateResponse.statusCode, 200);
+  assert.equal(updateResponse.body.status, 'done');
+
+  const deleteResponse = await app.handle({ method: 'DELETE', path: `/tasks/${taskId}` });
+  assert.equal(deleteResponse.statusCode, 204);
+
+  const notFoundResponse = await app.handle({ method: 'GET', path: `/tasks/${taskId}` });
+  assert.equal(notFoundResponse.statusCode, 404);
+});
+
+test('validation middleware blocks invalid payloads', async () => {
+  resetTasks();
+  const app = createApp();
+
+  const invalidCreate = await app.handle({ method: 'POST', path: '/tasks', body: { description: 'Missing title' } });
+  assert.equal(invalidCreate.statusCode, 400);
+  assert.equal(invalidCreate.body.message, 'Invalid request body');
+
+  const invalidUpdate = await app.handle({ method: 'PATCH', path: '/tasks/not-an-id', body: { status: 'unknown' } });
+  assert.equal(invalidUpdate.statusCode, 400);
+  assert.equal(invalidUpdate.body.message, 'Invalid request body');
+});

--- a/src/__tests__/taskService.test.js
+++ b/src/__tests__/taskService.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  createTask,
+  deleteTask,
+  getAllTasks,
+  getTaskById,
+  resetTasks,
+  updateTask,
+} from '../services/taskService.js';
+
+test('taskService supports create/read/update/delete', () => {
+  resetTasks();
+
+  const created = createTask({ title: 'Write docs', description: 'Document API', status: 'pending' });
+  assert.ok(created.id);
+
+  const fetched = getTaskById(created.id);
+  assert.equal(fetched.title, 'Write docs');
+
+  const updated = updateTask(created.id, { status: 'done' });
+  assert.equal(updated.status, 'done');
+  assert.notEqual(updated.updatedAt, created.updatedAt);
+
+  const tasks = getAllTasks();
+  assert.equal(tasks.length, 1);
+
+  deleteTask(created.id);
+  assert.equal(getAllTasks().length, 0);
+});

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,156 @@
+import { errorHandler } from './middleware/errorHandler.js';
+import { registerTaskRoutes } from './routes/taskRoutes.js';
+import { HttpError } from './utils/httpError.js';
+
+class ResponseMock {
+  constructor() {
+    this.statusCode = 200;
+    this.body = null;
+    this.headersSent = false;
+  }
+
+  status(code) {
+    this.statusCode = code;
+    return this;
+  }
+
+  json(payload) {
+    this.body = payload;
+    this.headersSent = true;
+    return this;
+  }
+}
+
+const matchRoute = (pattern, path) => {
+  const patternParts = pattern.split('/').filter(Boolean);
+  const pathParts = path.split('/').filter(Boolean);
+
+  if (patternParts.length !== pathParts.length) {
+    return null;
+  }
+
+  const params = {};
+
+  for (let i = 0; i < patternParts.length; i += 1) {
+    const part = patternParts[i];
+    const pathPart = pathParts[i];
+    if (part.startsWith(':')) {
+      params[part.slice(1)] = pathPart;
+    } else if (part !== pathPart) {
+      return null;
+    }
+  }
+
+  return params;
+};
+
+class MiniApp {
+  constructor() {
+    this.routes = [];
+    this.middlewares = [];
+    this.errorMiddlewares = [];
+  }
+
+  use(middleware) {
+    this.middlewares.push(middleware);
+  }
+
+  useError(middleware) {
+    this.errorMiddlewares.push(middleware);
+  }
+
+  register(method, path, ...handlers) {
+    this.routes.push({ method, path, handlers });
+  }
+
+  post(path, ...handlers) {
+    this.register('POST', path, ...handlers);
+  }
+
+  get(path, ...handlers) {
+    this.register('GET', path, ...handlers);
+  }
+
+  patch(path, ...handlers) {
+    this.register('PATCH', path, ...handlers);
+  }
+
+  delete(path, ...handlers) {
+    this.register('DELETE', path, ...handlers);
+  }
+
+  async handle(request) {
+    const { method, path, body } = request;
+    const res = new ResponseMock();
+    const routeMatch = this.routes.find((route) =>
+      route.method === method && matchRoute(route.path, path)
+    );
+
+    const params = routeMatch ? matchRoute(routeMatch.path, path) : {};
+    const req = { ...request, params: params || {}, body: body ?? {} };
+
+    const callErrorHandlers = async (error) => {
+      if (this.errorMiddlewares.length === 0) {
+        res.status(error.statusCode || 500).json({ message: error.message });
+        return;
+      }
+
+      let index = 0;
+      const nextError = async (err) => {
+        const handler = this.errorMiddlewares[index];
+        index += 1;
+        if (!handler) {
+          res.status(err.statusCode || 500).json({ message: err.message });
+          return;
+        }
+        try {
+          await handler(err, req, res, nextError);
+        } catch (handlerError) {
+          await nextError(handlerError);
+        }
+      };
+
+      await nextError(error);
+    };
+
+    if (!routeMatch) {
+      await callErrorHandlers(new HttpError(404, 'Not Found'));
+      return res;
+    }
+
+    const stack = [...this.middlewares, ...routeMatch.handlers];
+    let index = 0;
+
+    const next = async (err) => {
+      if (err) {
+        await callErrorHandlers(err);
+        return;
+      }
+
+      const handler = stack[index];
+      index += 1;
+
+      if (!handler) {
+        return;
+      }
+
+      try {
+        await handler(req, res, next);
+      } catch (error) {
+        await callErrorHandlers(error);
+      }
+    };
+
+    await next();
+    return res;
+  }
+}
+
+export const createApp = () => {
+  const app = new MiniApp();
+  registerTaskRoutes(app);
+  app.useError(errorHandler);
+  return app;
+};
+
+export { MiniApp };

--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -1,0 +1,52 @@
+import {
+  createTask,
+  getAllTasks,
+  getTaskById,
+  updateTask,
+  deleteTask,
+} from '../services/taskService.js';
+
+export const createTaskHandler = (req, res, next) => {
+  try {
+    const task = createTask(req.validatedBody);
+    return res.status(201).json(task);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getTasksHandler = (_req, res, next) => {
+  try {
+    const tasks = getAllTasks();
+    return res.status(200).json(tasks);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getTaskHandler = (req, res, next) => {
+  try {
+    const task = getTaskById(req.validatedParams.id);
+    return res.status(200).json(task);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const updateTaskHandler = (req, res, next) => {
+  try {
+    const task = updateTask(req.validatedParams.id, req.validatedBody);
+    return res.status(200).json(task);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const deleteTaskHandler = (req, res, next) => {
+  try {
+    deleteTask(req.validatedParams.id);
+    return res.status(204).json({ message: 'Task deleted' });
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,0 +1,18 @@
+import { HttpError } from '../utils/httpError.js';
+
+export const errorHandler = (err, _req, res, next) => {
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  const statusCode = err instanceof HttpError ? err.statusCode : 500;
+  const payload = {
+    message: err.message || 'Internal Server Error',
+  };
+
+  if (err.details) {
+    payload.details = err.details;
+  }
+
+  res.status(statusCode).json(payload);
+};

--- a/src/middleware/validationMiddleware.js
+++ b/src/middleware/validationMiddleware.js
@@ -1,0 +1,27 @@
+import { HttpError } from '../utils/httpError.js';
+
+const formatIssues = (issues) =>
+  issues.map(({ path, message }) => ({
+    path: path.join('.'),
+    message,
+  }));
+
+export const validateBody = (schema) => (req, _res, next) => {
+  const result = schema.safeParse(req.body ?? {});
+  if (!result.success) {
+    return next(new HttpError(400, 'Invalid request body', formatIssues(result.error.issues)));
+  }
+
+  req.validatedBody = result.data;
+  return next();
+};
+
+export const validateParams = (schema) => (req, _res, next) => {
+  const result = schema.safeParse(req.params ?? {});
+  if (!result.success) {
+    return next(new HttpError(400, 'Invalid route parameters', formatIssues(result.error.issues)));
+  }
+
+  req.validatedParams = result.data;
+  return next();
+};

--- a/src/routes/taskRoutes.js
+++ b/src/routes/taskRoutes.js
@@ -1,0 +1,35 @@
+import {
+  createTaskHandler,
+  deleteTaskHandler,
+  getTaskHandler,
+  getTasksHandler,
+  updateTaskHandler,
+} from '../controllers/taskController.js';
+import { validateBody, validateParams } from '../middleware/validationMiddleware.js';
+import { z } from '../validation/zodLite.js';
+
+const taskCreateSchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  description: z.string().optional(),
+  status: z.enum(['pending', 'in-progress', 'done']).optional(),
+});
+
+const taskUpdateSchema = z.object({
+  title: z.string().min(1, 'Title is required').optional(),
+  description: z.string().optional(),
+  status: z.enum(['pending', 'in-progress', 'done']).optional(),
+});
+
+const taskIdSchema = z.object({
+  id: z.string().min(1, 'Task id is required'),
+});
+
+export const registerTaskRoutes = (router) => {
+  router.post('/tasks', validateBody(taskCreateSchema), createTaskHandler);
+  router.get('/tasks', getTasksHandler);
+  router.get('/tasks/:id', validateParams(taskIdSchema), getTaskHandler);
+  router.patch('/tasks/:id', validateParams(taskIdSchema), validateBody(taskUpdateSchema), updateTaskHandler);
+  router.delete('/tasks/:id', validateParams(taskIdSchema), deleteTaskHandler);
+};
+
+export { taskCreateSchema, taskUpdateSchema, taskIdSchema };

--- a/src/services/taskService.js
+++ b/src/services/taskService.js
@@ -1,0 +1,41 @@
+import { randomUUID } from 'node:crypto';
+import { buildNotFoundError } from '../utils/httpError.js';
+
+const tasks = new Map();
+
+export const createTask = ({ title, description, status = 'pending' }) => {
+  const id = randomUUID();
+  const now = new Date().toISOString();
+  const task = { id, title, description: description ?? '', status, createdAt: now, updatedAt: now };
+  tasks.set(id, task);
+  return task;
+};
+
+export const getAllTasks = () => Array.from(tasks.values());
+
+export const getTaskById = (id) => {
+  const task = tasks.get(id);
+  if (!task) {
+    throw buildNotFoundError('Task', id);
+  }
+  return task;
+};
+
+export const updateTask = (id, payload) => {
+  const existing = getTaskById(id);
+  const updated = {
+    ...existing,
+    ...payload,
+    updatedAt: new Date().toISOString(),
+  };
+  tasks.set(id, updated);
+  return updated;
+};
+
+export const deleteTask = (id) => {
+  if (!tasks.delete(id)) {
+    throw buildNotFoundError('Task', id);
+  }
+};
+
+export const resetTasks = () => tasks.clear();

--- a/src/utils/httpError.js
+++ b/src/utils/httpError.js
@@ -1,0 +1,14 @@
+export class HttpError extends Error {
+  constructor(statusCode, message, details) {
+    super(message);
+    this.statusCode = statusCode;
+    if (details) {
+      this.details = details;
+    }
+  }
+}
+
+export const buildNotFoundError = (entity, identifier = '') => {
+  const label = identifier ? `${entity} with id ${identifier}` : entity;
+  return new HttpError(404, `${label} not found`);
+};

--- a/src/validation/zodLite.js
+++ b/src/validation/zodLite.js
@@ -1,0 +1,127 @@
+class ZodValidationError extends Error {
+  constructor(issues) {
+    super('Validation failed');
+    this.issues = issues;
+  }
+}
+
+class ZString {
+  constructor() {
+    this._min = null;
+  }
+
+  min(value, message = `Expected at least ${value} characters`) {
+    this._min = { value, message };
+    return this;
+  }
+
+  parse(input, path = []) {
+    const issues = [];
+    if (typeof input !== 'string') {
+      issues.push({ path, message: 'Expected string' });
+    } else if (this._min && input.length < this._min.value) {
+      issues.push({ path, message: this._min.message });
+    }
+
+    if (issues.length) {
+      throw new ZodValidationError(issues);
+    }
+    return input;
+  }
+
+  optional() {
+    return new ZOptional(this);
+  }
+}
+
+class ZEnum {
+  constructor(options) {
+    this.options = options;
+  }
+
+  parse(input, path = []) {
+    const issues = [];
+    if (typeof input !== 'string' || !this.options.includes(input)) {
+      issues.push({ path, message: `Expected one of: ${this.options.join(', ')}` });
+    }
+
+    if (issues.length) {
+      throw new ZodValidationError(issues);
+    }
+    return input;
+  }
+
+  optional() {
+    return new ZOptional(this);
+  }
+}
+
+class ZOptional {
+  constructor(inner) {
+    this.inner = inner;
+  }
+
+  parse(input, path = []) {
+    if (input === undefined) {
+      return undefined;
+    }
+    return this.inner.parse(input, path);
+  }
+
+  optional() {
+    return this;
+  }
+}
+
+class ZObject {
+  constructor(shape) {
+    this.shape = shape;
+  }
+
+  parse(input) {
+    const issues = [];
+    if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+      issues.push({ path: [], message: 'Expected object' });
+      throw new ZodValidationError(issues);
+    }
+
+    const data = {};
+    for (const [key, schema] of Object.entries(this.shape)) {
+      try {
+        const value = schema.parse(input[key], [key]);
+        if (value !== undefined) {
+          data[key] = value;
+        }
+      } catch (error) {
+        if (error instanceof ZodValidationError) {
+          issues.push(...error.issues);
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    if (issues.length) {
+      throw new ZodValidationError(issues);
+    }
+
+    return data;
+  }
+
+  safeParse(input) {
+    try {
+      const data = this.parse(input);
+      return { success: true, data };
+    } catch (error) {
+      return { success: false, error };
+    }
+  }
+}
+
+export const z = {
+  string: () => new ZString(),
+  enum: (options) => new ZEnum(options),
+  object: (shape) => new ZObject(shape),
+};
+
+export { ZodValidationError };


### PR DESCRIPTION
## Summary
- add in-memory task service and controllers with global error handling
- register task CRUD routes with schema-based validation middleware
- provide node-based tests covering service and controller flows

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fcac9d724832ea9082bb521975b65)