### PR TITLE
Add JWT authentication and protect task routes

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,17 +1,19 @@
-
 # ANTYO Focus Backend
 
-Backend data layer powered by [Prisma](https://www.prisma.io/) with a SQLite database for local development. The schema includes `User`, `Task`, and `FocusSession` models plus relationships to support task tracking and focus sessions.
+Backend Express server for ANTYO-Focus powered by [Prisma](https://www.prisma.io/) and SQLite for local development. The schema includes `User`, `Task`, and `FocusSession` models plus relationships to support task tracking and focus sessions.
 
 ## Environment variables
-Create a `.env` file in the `backend` directory with the database connection string:
+Create a `.env` file in the `backend` directory with the database connection string and JWT settings:
 
 ```bash
 DATABASE_URL="file:./prisma/dev.db"
+JWT_SECRET="replace-with-strong-secret"
+JWT_EXPIRES_IN="1d"
+PORT=3001
 ```
 
-## Database setup
-1. Install backend dependencies:
+## Setup
+1. Install dependencies:
    ```bash
    npm install
    ```
@@ -23,43 +25,26 @@ DATABASE_URL="file:./prisma/dev.db"
    ```bash
    npm run prisma:generate
    ```
-4. Seed the database with demo data:
+4. Seed the database with demo data (uses the password `password123` for the demo user):
    ```bash
    npm run prisma:seed
    ```
-
-## Schema overview
-- **User**: base account entity that owns tasks.
-- **Task**: contains title, description, status, due date, and belongs to a user.
-- **FocusSession**: captures start/end times, duration, and status for a task session.
-
-Migrations and seed scripts live in `prisma/` and the Prisma client is configured in `src/config/db.js`.
-=======
-# Backend Server
-
-Backend Express server for ANTYO-Focus.
-
-## Setup
-
-1. Install dependencies:
-   ```bash
-   npm install
-   ```
-2. Copy `.env.example` to `.env` if you want to override defaults (e.g., `PORT`).
-3. Start the server:
+5. Start the server:
    ```bash
    npm start
    ```
 
-## Development
-
-Run with automatic reloads (requires `nodemon` from devDependencies):
-
+For development with automatic reloads (requires `nodemon` from devDependencies):
 ```bash
 npm run dev
 ```
 
 ## Healthcheck
-
 A healthcheck route is available at `GET /api/health` and returns a simple status payload.
 
+## Auth routes
+New authentication endpoints are exposed at:
+- `POST /api/auth/register` – register a user with hashed password storage.
+- `POST /api/auth/login` – authenticate and receive a JWT for protected routes.
+
+Task and focus session routes (`/api/tasks`, `/api/sessions`) are protected via JWT middleware.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,35 +1,26 @@
 {
-
   "name": "antyo-focus-backend",
   "version": "0.1.0",
   "private": true,
-  "type": "module",
-  "scripts": {
-    "prisma:migrate": "prisma migrate dev --name init",
-    "prisma:generate": "prisma generate",
-    "prisma:seed": "prisma db seed"
-  },
-  "dependencies": {
-    "@prisma/client": "^5.22.0"
-  },
-  "devDependencies": {
-    "prisma": "^5.22.0"
-
-  "name": "backend",
-  "version": "1.0.0",
   "description": "Backend server for ANTYO-Focus",
   "main": "src/index.js",
   "type": "commonjs",
   "scripts": {
     "start": "node src/index.js",
-    "dev": "nodemon src/index.js"
+    "dev": "nodemon src/index.js",
+    "prisma:migrate": "prisma migrate dev --name init",
+    "prisma:generate": "prisma generate",
+    "prisma:seed": "prisma db seed"
   },
   "dependencies": {
+    "@prisma/client": "^5.22.0",
+    "bcryptjs": "^2.4.3",
     "dotenv": "^16.4.5",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
-    "nodemon": "^3.1.7"
-
+    "nodemon": "^3.1.7",
+    "prisma": "^5.22.0"
   }
 }

--- a/backend/prisma/migrations/20251203000001_add_password_hash/migration.sql
+++ b/backend/prisma/migrations/20251203000001_add_password_hash/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "passwordHash" TEXT NOT NULL DEFAULT '';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -23,12 +23,13 @@ enum FocusSessionStatus {
 }
 
 model User {
-  id        Int      @id @default(autoincrement())
-  email     String   @unique
-  name      String?
-  createdAt DateTime @default(now())
+  id           Int      @id @default(autoincrement())
+  email        String   @unique
+  name         String?
+  passwordHash String
+  createdAt    DateTime @default(now())
 
-  tasks     Task[]
+  tasks Task[]
 }
 
 model Task {

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -1,14 +1,18 @@
-import { PrismaClient, TaskStatus, FocusSessionStatus } from '@prisma/client';
+const { PrismaClient, TaskStatus, FocusSessionStatus } = require('@prisma/client');
+const bcrypt = require('bcryptjs');
 
 const prisma = new PrismaClient();
 
 async function main() {
+  const passwordHash = await bcrypt.hash('password123', 10);
+
   const user = await prisma.user.upsert({
     where: { email: 'demo@antyo.focus' },
     update: {},
     create: {
       email: 'demo@antyo.focus',
       name: 'Demo User',
+      passwordHash,
     },
   });
 

--- a/backend/src/config/config.js
+++ b/backend/src/config/config.js
@@ -4,7 +4,9 @@ dotenv.config();
 
 const config = {
   port: process.env.PORT || 3001,
-  nodeEnv: process.env.NODE_ENV || 'development'
+  nodeEnv: process.env.NODE_ENV || 'development',
+  jwtSecret: process.env.JWT_SECRET || 'dev-secret-key',
+  jwtExpiresIn: process.env.JWT_EXPIRES_IN || '1d'
 };
 
 module.exports = config;

--- a/backend/src/config/db.js
+++ b/backend/src/config/db.js
@@ -1,6 +1,6 @@
-import { PrismaClient } from '@prisma/client';
+const { PrismaClient } = require('@prisma/client');
 
-const globalForPrisma = globalThis;
+const globalForPrisma = global;
 
 const prisma = globalForPrisma.prisma || new PrismaClient({
   log: ['error', 'warn'],
@@ -10,4 +10,4 @@ if (process.env.NODE_ENV !== 'production') {
   globalForPrisma.prisma = prisma;
 }
 
-export default prisma;
+module.exports = prisma;

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,0 +1,36 @@
+const authService = require('../services/authService');
+
+const register = async (req, res) => {
+  const { email, name, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ message: 'Email and password are required' });
+  }
+
+  try {
+    const user = await authService.registerUser({ email, name, password });
+    return res.status(201).json({ user });
+  } catch (error) {
+    const statusCode = error.statusCode || 500;
+    return res.status(statusCode).json({ message: error.message || 'Registration failed' });
+  }
+};
+
+const login = async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ message: 'Email and password are required' });
+  }
+
+  try {
+    const result = await authService.loginUser({ email, password });
+    return res.json(result);
+  } catch (error) {
+    const statusCode = error.statusCode || 500;
+    return res.status(statusCode).json({ message: error.message || 'Login failed' });
+  }
+};
+
+module.exports = {
+  register,
+  login,
+};

--- a/backend/src/controllers/focusSessionController.js
+++ b/backend/src/controllers/focusSessionController.js
@@ -1,0 +1,14 @@
+const focusSessionService = require('../services/focusSessionService');
+
+const listSessions = async (req, res) => {
+  try {
+    const sessions = await focusSessionService.getSessionsForUser(req.user.id);
+    return res.json({ sessions });
+  } catch (error) {
+    return res.status(500).json({ message: 'Failed to fetch focus sessions' });
+  }
+};
+
+module.exports = {
+  listSessions,
+};

--- a/backend/src/controllers/taskController.js
+++ b/backend/src/controllers/taskController.js
@@ -1,0 +1,14 @@
+const taskService = require('../services/taskService');
+
+const listTasks = async (req, res) => {
+  try {
+    const tasks = await taskService.getTasksForUser(req.user.id);
+    return res.json({ tasks });
+  } catch (error) {
+    return res.status(500).json({ message: 'Failed to fetch tasks' });
+  }
+};
+
+module.exports = {
+  listTasks,
+};

--- a/backend/src/middleware/authMiddleware.js
+++ b/backend/src/middleware/authMiddleware.js
@@ -1,0 +1,28 @@
+const jwt = require('jsonwebtoken');
+const config = require('../config/config');
+const userRepository = require('../repositories/userRepository');
+
+const authMiddleware = async (req, res, next) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Authorization header missing' });
+  }
+
+  const token = authHeader.split(' ')[1];
+
+  try {
+    const decoded = jwt.verify(token, config.jwtSecret);
+    const user = await userRepository.findById(decoded.sub);
+
+    if (!user) {
+      return res.status(401).json({ message: 'User not found for token' });
+    }
+
+    req.user = { id: user.id, email: user.email };
+    return next();
+  } catch (error) {
+    return res.status(401).json({ message: 'Invalid or expired token' });
+  }
+};
+
+module.exports = authMiddleware;

--- a/backend/src/repositories/focusSessionRepository.js
+++ b/backend/src/repositories/focusSessionRepository.js
@@ -1,0 +1,12 @@
+const prisma = require('../config/db');
+
+const findSessionsByUserId = async (userId) =>
+  prisma.focusSession.findMany({
+    where: { task: { userId } },
+    include: { task: true },
+    orderBy: { startTime: 'desc' },
+  });
+
+module.exports = {
+  findSessionsByUserId,
+};

--- a/backend/src/repositories/taskRepository.js
+++ b/backend/src/repositories/taskRepository.js
@@ -1,0 +1,12 @@
+const prisma = require('../config/db');
+
+const findTasksByUserId = async (userId) =>
+  prisma.task.findMany({
+    where: { userId },
+    include: { sessions: true },
+    orderBy: { createdAt: 'desc' },
+  });
+
+module.exports = {
+  findTasksByUserId,
+};

--- a/backend/src/repositories/userRepository.js
+++ b/backend/src/repositories/userRepository.js
@@ -1,0 +1,22 @@
+const prisma = require('../config/db');
+
+const findByEmail = async (email) =>
+  prisma.user.findUnique({
+    where: { email },
+  });
+
+const createUser = async (data) =>
+  prisma.user.create({
+    data,
+  });
+
+const findById = async (id) =>
+  prisma.user.findUnique({
+    where: { id },
+  });
+
+module.exports = {
+  findByEmail,
+  createUser,
+  findById,
+};

--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -1,0 +1,9 @@
+const { Router } = require('express');
+const authController = require('../controllers/authController');
+
+const router = Router();
+
+router.post('/register', authController.register);
+router.post('/login', authController.login);
+
+module.exports = router;

--- a/backend/src/routes/focusSession.routes.js
+++ b/backend/src/routes/focusSession.routes.js
@@ -1,0 +1,10 @@
+const { Router } = require('express');
+const focusSessionController = require('../controllers/focusSessionController');
+const authMiddleware = require('../middleware/authMiddleware');
+
+const router = Router();
+
+router.use(authMiddleware);
+router.get('/', focusSessionController.listSessions);
+
+module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -1,9 +1,16 @@
 const { Router } = require('express');
 const healthRoutes = require('./health.routes');
+const authRoutes = require('./auth.routes');
+const taskRoutes = require('./task.routes');
+const focusSessionRoutes = require('./focusSession.routes');
 
 const router = Router();
 
 router.use('/health', healthRoutes);
+router.use('/auth', authRoutes);
+router.use('/tasks', taskRoutes);
+router.use('/sessions', focusSessionRoutes);
+
 router.get('/', (_req, res) => {
   res.json({ message: 'API is running' });
 });

--- a/backend/src/routes/task.routes.js
+++ b/backend/src/routes/task.routes.js
@@ -1,0 +1,10 @@
+const { Router } = require('express');
+const taskController = require('../controllers/taskController');
+const authMiddleware = require('../middleware/authMiddleware');
+
+const router = Router();
+
+router.use(authMiddleware);
+router.get('/', taskController.listTasks);
+
+module.exports = router;

--- a/backend/src/services/authService.js
+++ b/backend/src/services/authService.js
@@ -1,0 +1,64 @@
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const config = require('../config/config');
+const userRepository = require('../repositories/userRepository');
+
+const sanitizeUser = (user) => {
+  const { passwordHash, ...safeUser } = user;
+  return safeUser;
+};
+
+const registerUser = async ({ email, name, password }) => {
+  const existingUser = await userRepository.findByEmail(email);
+  if (existingUser) {
+    const error = new Error('Email already registered');
+    error.statusCode = 409;
+    throw error;
+  }
+
+  const passwordHash = await bcrypt.hash(password, 10);
+  const newUser = await userRepository.createUser({
+    email,
+    name,
+    passwordHash,
+  });
+
+  return sanitizeUser(newUser);
+};
+
+const generateToken = (user) =>
+  jwt.sign(
+    {
+      sub: user.id,
+      email: user.email,
+    },
+    config.jwtSecret,
+    { expiresIn: config.jwtExpiresIn }
+  );
+
+const loginUser = async ({ email, password }) => {
+  const user = await userRepository.findByEmail(email);
+  if (!user) {
+    const error = new Error('Invalid email or password');
+    error.statusCode = 401;
+    throw error;
+  }
+
+  const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
+  if (!isPasswordValid) {
+    const error = new Error('Invalid email or password');
+    error.statusCode = 401;
+    throw error;
+  }
+
+  const token = generateToken(user);
+  return {
+    token,
+    user: sanitizeUser(user),
+  };
+};
+
+module.exports = {
+  registerUser,
+  loginUser,
+};

--- a/backend/src/services/focusSessionService.js
+++ b/backend/src/services/focusSessionService.js
@@ -1,0 +1,7 @@
+const focusSessionRepository = require('../repositories/focusSessionRepository');
+
+const getSessionsForUser = async (userId) => focusSessionRepository.findSessionsByUserId(userId);
+
+module.exports = {
+  getSessionsForUser,
+};

--- a/backend/src/services/taskService.js
+++ b/backend/src/services/taskService.js
@@ -1,0 +1,7 @@
+const taskRepository = require('../repositories/taskRepository');
+
+const getTasksForUser = async (userId) => taskRepository.findTasksByUserId(userId);
+
+module.exports = {
+  getTasksForUser,
+};


### PR DESCRIPTION
## Summary
- add JWT-based authentication routes for registration and login with hashed passwords
- secure task and focus session endpoints with authentication middleware backed by Prisma repositories
- document required JWT environment variables and update Prisma schema and seed data

## Testing
- ⚠️ `npm install` *(fails in container: npm registry returns 403 Forbidden)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fd62c2240832e929bc3e7708b7758)