### PR TITLE
Add backend logging and quality scripts

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,8 +1,6 @@
-
-# Connection string for local SQLite database
-DATABASE_URL="file:./prisma/dev.db"
-
-# Server configuration
-PORT=3001
 NODE_ENV=development
-
+PORT=3001
+DATABASE_URL="file:./prisma/dev.db"
+JWT_SECRET="replace-with-strong-secret"
+JWT_EXPIRES_IN=1d
+LOG_LEVEL=info

--- a/backend/README.md
+++ b/backend/README.md
@@ -3,14 +3,13 @@
 Backend Express server for ANTYO-Focus powered by [Prisma](https://www.prisma.io/) and SQLite for local development. The schema includes `User`, `Task`, and `FocusSession` models plus relationships to support task tracking and focus sessions.
 
 ## Environment variables
-Create a `.env` file in the `backend` directory with the database connection string and JWT settings:
+Copy `.env.example` to `.env` in the `backend` directory and adjust as needed:
 
 ```bash
-DATABASE_URL="file:./prisma/dev.db"
-JWT_SECRET="replace-with-strong-secret"
-JWT_EXPIRES_IN="1d"
-PORT=3001
+cp .env.example .env
 ```
+
+Key variables include the server port, database connection string, JWT configuration, and the log level for the request logger.
 
 ## Setup
 1. Install dependencies:
@@ -38,6 +37,16 @@ For development with automatic reloads (requires `nodemon` from devDependencies)
 ```bash
 npm run dev
 ```
+
+## Quality
+- Lint the backend codebase:
+  ```bash
+  npm run lint
+  ```
+- Run Node's built-in test runner (no tests are defined yet):
+  ```bash
+  npm test
+  ```
 
 ## Healthcheck
 A healthcheck route is available at `GET /api/health` and returns a simple status payload.

--- a/backend/eslint.config.cjs
+++ b/backend/eslint.config.cjs
@@ -1,0 +1,29 @@
+const js = require('@eslint/js');
+
+module.exports = [
+  {
+    ignores: ['node_modules'],
+  },
+  {
+    files: ['**/*.js'],
+    rules: {
+      ...js.configs.recommended.rules,
+      'no-console': 'off',
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^[A-Z_]' }]
+    },
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'commonjs',
+      globals: {
+        process: 'readonly',
+        module: 'readonly',
+        require: 'readonly',
+        __dirname: 'readonly',
+        console: 'readonly',
+        global: 'readonly',
+        setTimeout: 'readonly',
+        setInterval: 'readonly'
+      }
+    }
+  }
+];

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
+    "lint": "eslint src --ext .js",
+    "test": "node --test",
     "prisma:migrate": "prisma migrate dev --name init",
     "prisma:generate": "prisma generate",
     "prisma:seed": "prisma db seed"
@@ -17,9 +19,12 @@
     "bcryptjs": "^2.4.3",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "winston": "^3.17.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.11.1",
+    "eslint": "^9.11.1",
     "nodemon": "^3.1.7",
     "prisma": "^5.22.0"
   }

--- a/backend/src/config/config.js
+++ b/backend/src/config/config.js
@@ -6,7 +6,8 @@ const config = {
   port: process.env.PORT || 3001,
   nodeEnv: process.env.NODE_ENV || 'development',
   jwtSecret: process.env.JWT_SECRET || 'dev-secret-key',
-  jwtExpiresIn: process.env.JWT_EXPIRES_IN || '1d'
+  jwtExpiresIn: process.env.JWT_EXPIRES_IN || '1d',
+  logLevel: process.env.LOG_LEVEL || 'info'
 };
 
 module.exports = config;

--- a/backend/src/controllers/focusSessionController.js
+++ b/backend/src/controllers/focusSessionController.js
@@ -1,10 +1,12 @@
 const focusSessionService = require('../services/focusSessionService');
+const { logger } = require('../middleware/logger');
 
 const listSessions = async (req, res) => {
   try {
     const sessions = await focusSessionService.getSessionsForUser(req.user.id);
     return res.json({ sessions });
   } catch (error) {
+    logger.error('Failed to fetch focus sessions', { error });
     return res.status(500).json({ message: 'Failed to fetch focus sessions' });
   }
 };

--- a/backend/src/controllers/taskController.js
+++ b/backend/src/controllers/taskController.js
@@ -1,10 +1,12 @@
 const taskService = require('../services/taskService');
+const { logger } = require('../middleware/logger');
 
 const listTasks = async (req, res) => {
   try {
     const tasks = await taskService.getTasksForUser(req.user.id);
     return res.json({ tasks });
   } catch (error) {
+    logger.error('Failed to fetch tasks', { error });
     return res.status(500).json({ message: 'Failed to fetch tasks' });
   }
 };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,12 +1,14 @@
 const express = require('express');
 const config = require('./config/config');
 const routes = require('./routes');
+const { logger, requestLoggerMiddleware } = require('./middleware/logger');
 
 const app = express();
 
 app.use(express.json());
+app.use(requestLoggerMiddleware);
 app.use('/api', routes);
 
 app.listen(config.port, () => {
-  console.log(`Server running in ${config.nodeEnv} mode on port ${config.port}`);
+  logger.info(`Server running in ${config.nodeEnv} mode on port ${config.port}`);
 });

--- a/backend/src/middleware/authMiddleware.js
+++ b/backend/src/middleware/authMiddleware.js
@@ -1,6 +1,7 @@
 const jwt = require('jsonwebtoken');
 const config = require('../config/config');
 const userRepository = require('../repositories/userRepository');
+const { logger } = require('./logger');
 
 const authMiddleware = async (req, res, next) => {
   const authHeader = req.headers.authorization;
@@ -21,6 +22,7 @@ const authMiddleware = async (req, res, next) => {
     req.user = { id: user.id, email: user.email };
     return next();
   } catch (error) {
+    logger.warn('JWT verification failed', { error });
     return res.status(401).json({ message: 'Invalid or expired token' });
   }
 };

--- a/backend/src/middleware/logger.js
+++ b/backend/src/middleware/logger.js
@@ -1,0 +1,44 @@
+const { createLogger, format, transports } = require('winston');
+const config = require('../config/config');
+
+const logger = createLogger({
+  level: config.logLevel,
+  format: format.combine(
+    format.timestamp(),
+    format.errors({ stack: true }),
+    format.json()
+  ),
+  transports: [
+    new transports.Console({
+      format: format.combine(
+        format.colorize(),
+        format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+        format.printf(({ timestamp, level, message, ...meta }) => {
+          const metaString = Object.keys(meta).length ? ` ${JSON.stringify(meta)}` : '';
+          return `${timestamp} [${level}]: ${message}${metaString}`;
+        })
+      )
+    })
+  ]
+});
+
+const requestLoggerMiddleware = (req, res, next) => {
+  const startTime = process.hrtime.bigint();
+
+  res.on('finish', () => {
+    const durationMs = Number(process.hrtime.bigint() - startTime) / 1e6;
+    const { method, originalUrl } = req;
+    const { statusCode } = res;
+
+    logger.info(`${method} ${originalUrl} ${statusCode} ${durationMs.toFixed(2)}ms`, {
+      method,
+      url: originalUrl,
+      statusCode,
+      durationMs: Number(durationMs.toFixed(2))
+    });
+  });
+
+  next();
+};
+
+module.exports = { logger, requestLoggerMiddleware };

--- a/backend/src/services/authService.js
+++ b/backend/src/services/authService.js
@@ -4,7 +4,7 @@ const config = require('../config/config');
 const userRepository = require('../repositories/userRepository');
 
 const sanitizeUser = (user) => {
-  const { passwordHash, ...safeUser } = user;
+  const { passwordHash: _passwordHash, ...safeUser } = user;
   return safeUser;
 };
 


### PR DESCRIPTION
## Summary
- add a Winston-based logger middleware to capture request and response details and wire it into the server and auth flow
- document environment configuration with a concrete `.env.example` and README instructions for backend quality checks
- introduce backend lint/test scripts with a Node-focused ESLint flat config

## Testing
- npm run lint
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fd7a063ac832e95512e560910cd7e)