### PR TITLE
Add API spec and document backend usage

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -34,9 +34,52 @@ Key variables include the server port, database connection string, JWT configura
    ```
 
 For development with automatic reloads (requires `nodemon` from devDependencies):
-```bash
-npm run dev
-```
+   ```bash
+   npm run dev
+   ```
+
+## Run locally
+1. Copy the environment file, adjust secrets, and confirm the Prisma `DATABASE_URL` points to a writable path (SQLite by default).
+   ```bash
+   cp .env.example .env
+   ```
+2. Install dependencies and generate the Prisma client.
+   ```bash
+   npm install
+   npm run prisma:migrate
+   npm run prisma:seed # optional demo data (password: password123)
+   ```
+3. Start the API server on the configured port (defaults to `3001`).
+   ```bash
+   npm start
+   ```
+   For auto-reload during development use:
+   ```bash
+   npm run dev
+   ```
+
+Once running, the API is available at `http://localhost:3001/api`.
+
+## Test the endpoints
+- Import `backend/openapi.yaml` into Postman/Insomnia or use `curl`:
+  ```bash
+  # Register a user
+  curl -X POST http://localhost:3001/api/auth/register \
+    -H "Content-Type: application/json" \
+    -d '{"email":"user@example.com","password":"password123","name":"Demo"}'
+
+  # Login and capture the JWT
+  TOKEN=$(curl -s -X POST http://localhost:3001/api/auth/login \
+    -H "Content-Type: application/json" \
+    -d '{"email":"user@example.com","password":"password123"}' | jq -r .token)
+
+  # Fetch protected resources
+  curl -H "Authorization: Bearer $TOKEN" http://localhost:3001/api/tasks
+  curl -H "Authorization: Bearer $TOKEN" http://localhost:3001/api/sessions
+  ```
+- The login example uses `jq` to extract the token; copy the token manually if `jq` is unavailable.
+- JWT-protected routes include `/api/tasks` and `/api/sessions`; unauthenticated requests return `401`.
+- Auth routes (`/api/auth/register` and `/api/auth/login`) accept JSON payloads with `email` and `password`; `name` is optional during registration.
 
 ## Quality
 - Lint the backend codebase:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1,0 +1,247 @@
+openapi: 3.0.3
+info:
+  title: ANTYO Focus Backend API
+  version: "1.0.0"
+  description: |
+    HTTP API for authentication, tasks, and focus sessions used by the ANTYO Focus application.
+servers:
+  - url: http://localhost:3001/api
+    description: Local development server
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        email:
+          type: string
+          format: email
+          example: user@example.com
+        name:
+          type: string
+          nullable: true
+          example: Demo User
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-06-01T12:00:00.000Z
+      required:
+        - id
+        - email
+        - createdAt
+    Task:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 12
+        title:
+          type: string
+          example: Write documentation
+        description:
+          type: string
+          nullable: true
+          example: Draft README and API specs
+        status:
+          type: string
+          enum: [PENDING, IN_PROGRESS, COMPLETED]
+          example: PENDING
+        dueDate:
+          type: string
+          format: date-time
+          nullable: true
+          example: 2024-09-20T15:00:00.000Z
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-09-10T09:30:00.000Z
+        userId:
+          type: integer
+          example: 1
+        sessions:
+          type: array
+          items:
+            $ref: '#/components/schemas/FocusSession'
+      required:
+        - id
+        - title
+        - status
+        - createdAt
+        - userId
+        - sessions
+    FocusSession:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 4
+        startTime:
+          type: string
+          format: date-time
+          example: 2024-09-12T10:00:00.000Z
+        endTime:
+          type: string
+          format: date-time
+          nullable: true
+          example: 2024-09-12T10:25:00.000Z
+        durationSeconds:
+          type: integer
+          example: 1500
+        status:
+          type: string
+          enum: [PLANNED, ACTIVE, COMPLETED]
+          example: COMPLETED
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-09-12T10:00:00.000Z
+        taskId:
+          type: integer
+          example: 12
+      required:
+        - id
+        - startTime
+        - durationSeconds
+        - status
+        - createdAt
+        - taskId
+    FocusSessionWithTask:
+      allOf:
+        - $ref: '#/components/schemas/FocusSession'
+        - type: object
+          properties:
+            task:
+              $ref: '#/components/schemas/Task'
+          required:
+            - task
+paths:
+  /auth/register:
+    post:
+      summary: Register a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: user@example.com
+                name:
+                  type: string
+                  example: Demo User
+                password:
+                  type: string
+                  format: password
+                  example: password123
+              required:
+                - email
+                - password
+      responses:
+        '201':
+          description: User created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user:
+                    $ref: '#/components/schemas/User'
+                required:
+                  - user
+        '400':
+          description: Missing required fields
+        '409':
+          description: Email already registered
+  /auth/login:
+    post:
+      summary: Log in and receive a JWT
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: user@example.com
+                password:
+                  type: string
+                  format: password
+                  example: password123
+              required:
+                - email
+                - password
+      responses:
+        '200':
+          description: Login succeeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                    example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+                  user:
+                    $ref: '#/components/schemas/User'
+                required:
+                  - token
+                  - user
+        '400':
+          description: Missing credentials
+        '401':
+          description: Invalid email or password
+  /tasks:
+    get:
+      summary: List tasks for the authenticated user
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Tasks retrieved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tasks:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Task'
+                required:
+                  - tasks
+        '401':
+          description: Missing or invalid JWT
+  /sessions:
+    get:
+      summary: List focus sessions for the authenticated user
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Sessions retrieved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sessions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/FocusSessionWithTask'
+                required:
+                  - sessions
+        '401':
+          description: Missing or invalid JWT


### PR DESCRIPTION
## Summary
- add an OpenAPI 3.0 specification covering authentication, task, and focus session endpoints
- document how to run the backend locally and exercise the endpoints with curl or an API client

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fd90366c0832eab13ced4cbbdb2a0)