### PR TITLE
Add task CRUD, session lifecycle, and dashboard API

### DIFF
--- a/backend/src/controllers/dashboardController.js
+++ b/backend/src/controllers/dashboardController.js
@@ -1,0 +1,16 @@
+const dashboardService = require('../services/dashboardService');
+const { logger } = require('../middleware/logger');
+
+const getDashboard = async (req, res) => {
+  try {
+    const summary = await dashboardService.getDashboardSummary(req.user.id);
+    return res.json({ summary });
+  } catch (error) {
+    logger.error('Failed to build dashboard summary', { error });
+    return res.status(500).json({ message: 'Failed to load dashboard' });
+  }
+};
+
+module.exports = {
+  getDashboard,
+};

--- a/backend/src/controllers/focusSessionController.js
+++ b/backend/src/controllers/focusSessionController.js
@@ -1,3 +1,4 @@
+const { FocusSessionStatus, TaskStatus } = require('@prisma/client');
 const focusSessionService = require('../services/focusSessionService');
 const { logger } = require('../middleware/logger');
 
@@ -11,6 +12,68 @@ const listSessions = async (req, res) => {
   }
 };
 
+const startSession = async (req, res) => {
+  const taskId = Number(req.body.taskId);
+  const targetDurationSeconds =
+    req.body.targetDurationSeconds !== undefined
+      ? Number(req.body.targetDurationSeconds)
+      : undefined;
+
+  if (!Number.isInteger(taskId)) {
+    return res.status(400).json({ message: 'taskId must be provided' });
+  }
+
+  if (targetDurationSeconds !== undefined && !Number.isInteger(targetDurationSeconds)) {
+    return res.status(400).json({ message: 'targetDurationSeconds must be an integer' });
+  }
+
+  try {
+    const session = await focusSessionService.startSession({
+      userId: req.user.id,
+      taskId,
+      targetDurationSeconds,
+    });
+    return res.status(201).json({ session });
+  } catch (error) {
+    const statusCode = error.statusCode || 500;
+    logger.error('Failed to start focus session', { error });
+    return res.status(statusCode).json({ message: error.message || 'Failed to start session' });
+  }
+};
+
+const stopSession = async (req, res) => {
+  const sessionId = Number(req.params.id);
+  if (!Number.isInteger(sessionId)) {
+    return res.status(400).json({ message: 'sessionId must be a number' });
+  }
+
+  const { status, taskStatus } = req.body;
+
+  if (status && !Object.values(FocusSessionStatus).includes(status)) {
+    return res.status(400).json({ message: 'Invalid session status' });
+  }
+
+  if (taskStatus && !Object.values(TaskStatus).includes(taskStatus)) {
+    return res.status(400).json({ message: 'Invalid task status' });
+  }
+
+  try {
+    const session = await focusSessionService.stopSession({
+      userId: req.user.id,
+      sessionId,
+      status,
+      taskStatus,
+    });
+    return res.json({ session });
+  } catch (error) {
+    const statusCode = error.statusCode || 500;
+    logger.error('Failed to stop focus session', { error });
+    return res.status(statusCode).json({ message: error.message || 'Failed to stop session' });
+  }
+};
+
 module.exports = {
   listSessions,
+  startSession,
+  stopSession,
 };

--- a/backend/src/controllers/taskController.js
+++ b/backend/src/controllers/taskController.js
@@ -1,6 +1,46 @@
 const taskService = require('../services/taskService');
 const { logger } = require('../middleware/logger');
 
+const validateTaskPayload = (payload, { requireTitle = false } = {}) => {
+  const errors = [];
+  const data = {};
+
+  if (requireTitle && !payload.title) {
+    errors.push('Title is required');
+  }
+
+  if (payload.title !== undefined) {
+    if (typeof payload.title !== 'string' || !payload.title.trim()) {
+      errors.push('Title must be a non-empty string');
+    } else {
+      data.title = payload.title.trim();
+    }
+  }
+
+  if (payload.description !== undefined) {
+    data.description = typeof payload.description === 'string' ? payload.description : null;
+  }
+
+  if (payload.status !== undefined) {
+    if (!taskService.ensureValidTaskStatus(payload.status)) {
+      errors.push('Invalid task status');
+    } else {
+      data.status = payload.status;
+    }
+  }
+
+  if (payload.dueDate !== undefined) {
+    const parsed = new Date(payload.dueDate);
+    if (Number.isNaN(parsed.getTime())) {
+      errors.push('Invalid dueDate');
+    } else {
+      data.dueDate = parsed;
+    }
+  }
+
+  return { errors, data };
+};
+
 const listTasks = async (req, res) => {
   try {
     const tasks = await taskService.getTasksForUser(req.user.id);
@@ -11,6 +51,65 @@ const listTasks = async (req, res) => {
   }
 };
 
+const createTask = async (req, res) => {
+  const { errors, data } = validateTaskPayload(req.body, { requireTitle: true });
+  if (errors.length > 0) {
+    return res.status(400).json({ message: errors.join(', ') });
+  }
+
+  try {
+    const task = await taskService.createTaskForUser({
+      ...data,
+      status: data.status || 'PENDING',
+      userId: req.user.id,
+    });
+    return res.status(201).json({ task });
+  } catch (error) {
+    logger.error('Failed to create task', { error });
+    return res.status(500).json({ message: 'Failed to create task' });
+  }
+};
+
+const updateTask = async (req, res) => {
+  const taskId = Number(req.params.id);
+  if (!Number.isInteger(taskId)) {
+    return res.status(400).json({ message: 'Task id must be a number' });
+  }
+
+  const { errors, data } = validateTaskPayload(req.body);
+  if (errors.length > 0) {
+    return res.status(400).json({ message: errors.join(', ') });
+  }
+
+  try {
+    const task = await taskService.updateTaskForUser({ taskId, userId: req.user.id, data });
+    return res.json({ task });
+  } catch (error) {
+    const statusCode = error.statusCode || 500;
+    logger.error('Failed to update task', { error });
+    return res.status(statusCode).json({ message: error.message || 'Failed to update task' });
+  }
+};
+
+const deleteTask = async (req, res) => {
+  const taskId = Number(req.params.id);
+  if (!Number.isInteger(taskId)) {
+    return res.status(400).json({ message: 'Task id must be a number' });
+  }
+
+  try {
+    await taskService.deleteTaskForUser({ taskId, userId: req.user.id });
+    return res.status(204).send();
+  } catch (error) {
+    const statusCode = error.statusCode || 500;
+    logger.error('Failed to delete task', { error });
+    return res.status(statusCode).json({ message: error.message || 'Failed to delete task' });
+  }
+};
+
 module.exports = {
   listTasks,
+  createTask,
+  updateTask,
+  deleteTask,
 };

--- a/backend/src/repositories/focusSessionRepository.js
+++ b/backend/src/repositories/focusSessionRepository.js
@@ -7,6 +7,33 @@ const findSessionsByUserId = async (userId) =>
     orderBy: { startTime: 'desc' },
   });
 
+const findSessionByIdForUser = async (sessionId, userId) =>
+  prisma.focusSession.findFirst({
+    where: { id: sessionId, task: { userId } },
+    include: { task: true },
+  });
+
+const createSession = async ({ taskId, startTime, durationSeconds, status }) =>
+  prisma.focusSession.create({
+    data: {
+      taskId,
+      startTime,
+      durationSeconds,
+      status,
+    },
+    include: { task: true },
+  });
+
+const updateSession = async (sessionId, data) =>
+  prisma.focusSession.update({
+    where: { id: sessionId },
+    data,
+    include: { task: true },
+  });
+
 module.exports = {
   findSessionsByUserId,
+  findSessionByIdForUser,
+  createSession,
+  updateSession,
 };

--- a/backend/src/repositories/taskRepository.js
+++ b/backend/src/repositories/taskRepository.js
@@ -7,6 +7,40 @@ const findTasksByUserId = async (userId) =>
     orderBy: { createdAt: 'desc' },
   });
 
+const findTaskByIdForUser = async (taskId, userId) =>
+  prisma.task.findFirst({
+    where: { id: taskId, userId },
+    include: { sessions: true },
+  });
+
+const createTask = async ({ title, description, status, dueDate, userId }) =>
+  prisma.task.create({
+    data: {
+      title,
+      description,
+      status,
+      dueDate,
+      userId,
+    },
+    include: { sessions: true },
+  });
+
+const updateTaskForUser = async (taskId, data) =>
+  prisma.task.update({
+    where: { id: taskId },
+    data,
+    include: { sessions: true },
+  });
+
+const deleteTaskForUser = async (taskId) =>
+  prisma.task.delete({
+    where: { id: taskId },
+  });
+
 module.exports = {
   findTasksByUserId,
+  findTaskByIdForUser,
+  createTask,
+  updateTaskForUser,
+  deleteTaskForUser,
 };

--- a/backend/src/routes/dashboard.routes.js
+++ b/backend/src/routes/dashboard.routes.js
@@ -1,0 +1,10 @@
+const { Router } = require('express');
+const dashboardController = require('../controllers/dashboardController');
+const authMiddleware = require('../middleware/authMiddleware');
+
+const router = Router();
+
+router.use(authMiddleware);
+router.get('/', dashboardController.getDashboard);
+
+module.exports = router;

--- a/backend/src/routes/focusSession.routes.js
+++ b/backend/src/routes/focusSession.routes.js
@@ -6,5 +6,7 @@ const router = Router();
 
 router.use(authMiddleware);
 router.get('/', focusSessionController.listSessions);
+router.post('/start', focusSessionController.startSession);
+router.post('/:id/stop', focusSessionController.stopSession);
 
 module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -3,6 +3,7 @@ const healthRoutes = require('./health.routes');
 const authRoutes = require('./auth.routes');
 const taskRoutes = require('./task.routes');
 const focusSessionRoutes = require('./focusSession.routes');
+const dashboardRoutes = require('./dashboard.routes');
 
 const router = Router();
 
@@ -10,6 +11,7 @@ router.use('/health', healthRoutes);
 router.use('/auth', authRoutes);
 router.use('/tasks', taskRoutes);
 router.use('/sessions', focusSessionRoutes);
+router.use('/dashboard', dashboardRoutes);
 
 router.get('/', (_req, res) => {
   res.json({ message: 'API is running' });

--- a/backend/src/routes/task.routes.js
+++ b/backend/src/routes/task.routes.js
@@ -6,5 +6,8 @@ const router = Router();
 
 router.use(authMiddleware);
 router.get('/', taskController.listTasks);
+router.post('/', taskController.createTask);
+router.put('/:id', taskController.updateTask);
+router.delete('/:id', taskController.deleteTask);
 
 module.exports = router;

--- a/backend/src/services/dashboardService.js
+++ b/backend/src/services/dashboardService.js
@@ -1,0 +1,66 @@
+const { TaskStatus, FocusSessionStatus } = require('@prisma/client');
+const prisma = require('../config/db');
+
+const buildStatusCounts = (groups, statuses) =>
+  statuses.reduce((acc, status) => {
+    const match = groups.find((group) => group.status === status);
+    return { ...acc, [status]: match ? match._count._all : 0 };
+  }, {});
+
+const getDashboardSummary = async (userId) => {
+  const [taskGroups, sessionGroups, sessionDurationAgg, recentSessions, upcomingTasks] =
+    await Promise.all([
+      prisma.task.groupBy({
+        by: ['status'],
+        _count: { _all: true },
+        where: { userId },
+      }),
+      prisma.focusSession.groupBy({
+        by: ['status'],
+        _count: { _all: true },
+        where: { task: { userId } },
+      }),
+      prisma.focusSession.aggregate({
+        where: { task: { userId } },
+        _sum: { durationSeconds: true },
+      }),
+      prisma.focusSession.findMany({
+        where: { task: { userId } },
+        include: { task: true },
+        orderBy: { startTime: 'desc' },
+        take: 5,
+      }),
+      prisma.task.findMany({
+        where: {
+          userId,
+          status: { not: TaskStatus.COMPLETED },
+        },
+        orderBy: [{ dueDate: 'asc' }, { createdAt: 'asc' }],
+        take: 5,
+      }),
+    ]);
+
+  const taskStatusCounts = buildStatusCounts(taskGroups, Object.values(TaskStatus));
+  const sessionStatusCounts = buildStatusCounts(sessionGroups, Object.values(FocusSessionStatus));
+
+  const totalTasks = Object.values(taskStatusCounts).reduce((sum, count) => sum + count, 0);
+  const totalSessions = Object.values(sessionStatusCounts).reduce((sum, count) => sum + count, 0);
+
+  return {
+    tasks: {
+      total: totalTasks,
+      byStatus: taskStatusCounts,
+      upcoming: upcomingTasks,
+    },
+    sessions: {
+      total: totalSessions,
+      durationSeconds: sessionDurationAgg._sum.durationSeconds || 0,
+      byStatus: sessionStatusCounts,
+      recent: recentSessions,
+    },
+  };
+};
+
+module.exports = {
+  getDashboardSummary,
+};

--- a/backend/src/services/focusSessionService.js
+++ b/backend/src/services/focusSessionService.js
@@ -1,7 +1,69 @@
+const { FocusSessionStatus, TaskStatus } = require('@prisma/client');
 const focusSessionRepository = require('../repositories/focusSessionRepository');
+const taskRepository = require('../repositories/taskRepository');
 
 const getSessionsForUser = async (userId) => focusSessionRepository.findSessionsByUserId(userId);
 
+const startSession = async ({ userId, taskId, targetDurationSeconds }) => {
+  const task = await taskRepository.findTaskByIdForUser(taskId, userId);
+
+  if (!task) {
+    const error = new Error('Task not found');
+    error.statusCode = 404;
+    throw error;
+  }
+
+  const startTime = new Date();
+  const session = await focusSessionRepository.createSession({
+    taskId,
+    startTime,
+    durationSeconds: targetDurationSeconds || 0,
+    status: FocusSessionStatus.ACTIVE,
+  });
+
+  if (task.status === TaskStatus.PENDING) {
+    await taskRepository.updateTaskForUser(taskId, { status: TaskStatus.IN_PROGRESS });
+    session.task.status = TaskStatus.IN_PROGRESS;
+  }
+
+  return session;
+};
+
+const stopSession = async ({ userId, sessionId, status, taskStatus }) => {
+  const session = await focusSessionRepository.findSessionByIdForUser(sessionId, userId);
+
+  if (!session) {
+    const error = new Error('Session not found');
+    error.statusCode = 404;
+    throw error;
+  }
+
+  if (session.status === FocusSessionStatus.COMPLETED && session.endTime) {
+    const error = new Error('Session already completed');
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const resolvedStatus = status || FocusSessionStatus.COMPLETED;
+  const endTime = new Date();
+  const durationSeconds = Math.max(0, Math.round((endTime - session.startTime) / 1000));
+
+  const updatedSession = await focusSessionRepository.updateSession(sessionId, {
+    endTime,
+    durationSeconds,
+    status: resolvedStatus,
+  });
+
+  if (taskStatus && Object.values(TaskStatus).includes(taskStatus)) {
+    await taskRepository.updateTaskForUser(session.taskId, { status: taskStatus });
+    updatedSession.task.status = taskStatus;
+  }
+
+  return updatedSession;
+};
+
 module.exports = {
   getSessionsForUser,
+  startSession,
+  stopSession,
 };

--- a/backend/src/services/taskService.js
+++ b/backend/src/services/taskService.js
@@ -1,7 +1,45 @@
+const { TaskStatus } = require('@prisma/client');
 const taskRepository = require('../repositories/taskRepository');
 
 const getTasksForUser = async (userId) => taskRepository.findTasksByUserId(userId);
 
+const getTaskByIdForUser = async (taskId, userId) => taskRepository.findTaskByIdForUser(taskId, userId);
+
+const createTaskForUser = async ({ title, description, status, dueDate, userId }) =>
+  taskRepository.createTask({ title, description, status, dueDate, userId });
+
+const updateTaskForUser = async ({ taskId, userId, data }) => {
+  const existing = await taskRepository.findTaskByIdForUser(taskId, userId);
+  if (!existing) {
+    const error = new Error('Task not found');
+    error.statusCode = 404;
+    throw error;
+  }
+
+  return taskRepository.updateTaskForUser(taskId, data);
+};
+
+const deleteTaskForUser = async ({ taskId, userId }) => {
+  const existing = await taskRepository.findTaskByIdForUser(taskId, userId);
+  if (!existing) {
+    const error = new Error('Task not found');
+    error.statusCode = 404;
+    throw error;
+  }
+
+  return taskRepository.deleteTaskForUser(taskId);
+};
+
+const ensureValidTaskStatus = (status) => {
+  const allowed = Object.values(TaskStatus);
+  return allowed.includes(status);
+};
+
 module.exports = {
   getTasksForUser,
+  getTaskByIdForUser,
+  createTaskForUser,
+  updateTaskForUser,
+  deleteTaskForUser,
+  ensureValidTaskStatus,
 };


### PR DESCRIPTION
## Summary
- add validation-backed CRUD endpoints for tasks tied to the authenticated user
- implement focus session start/stop flow that updates task progress and exposes session history
- introduce a protected dashboard endpoint that aggregates task and session metrics

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fdcbc1038832eaa8ffe0170f12004)