### PR TITLE
Add dashboard statistics fields to Prisma schema

### DIFF
--- a/backend/prisma/migrations/20251203000002_add_dashboard_stats/migration.sql
+++ b/backend/prisma/migrations/20251203000002_add_dashboard_stats/migration.sql
@@ -1,0 +1,31 @@
+-- Add dashboard/statistics fields to core tables and create daily stats table
+ALTER TABLE "User" ADD COLUMN "totalFocusSeconds" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "User" ADD COLUMN "totalDistractedSeconds" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "User" ADD COLUMN "weeklyFocusSeconds" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "User" ADD COLUMN "currentStreakDays" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "User" ADD COLUMN "longestStreakDays" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "User" ADD COLUMN "lastFocusDate" DATETIME;
+ALTER TABLE "User" ADD COLUMN "totalSessions" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "User" ADD COLUMN "completedTasks" INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE "Task" ADD COLUMN "completedAt" DATETIME;
+ALTER TABLE "Task" ADD COLUMN "focusDurationSeconds" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "Task" ADD COLUMN "distractionDurationSeconds" INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE "FocusSession" ADD COLUMN "focusDurationSeconds" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "FocusSession" ADD COLUMN "distractionDurationSeconds" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "FocusSession" ADD COLUMN "interruptionCount" INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE "FocusDailyStat" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "date" DATETIME NOT NULL,
+    "focusDurationSeconds" INTEGER NOT NULL DEFAULT 0,
+    "distractionDurationSeconds" INTEGER NOT NULL DEFAULT 0,
+    "sessionCount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" INTEGER NOT NULL,
+    CONSTRAINT "FocusDailyStat_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "FocusDailyStat_userId_date_key" ON "FocusDailyStat"("userId", "date");
+CREATE INDEX "FocusDailyStat_userId_idx" ON "FocusDailyStat"("userId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -29,7 +29,17 @@ model User {
   passwordHash String
   createdAt    DateTime @default(now())
 
-  tasks Task[]
+  totalFocusSeconds      Int      @default(0)
+  totalDistractedSeconds Int      @default(0)
+  weeklyFocusSeconds     Int      @default(0)
+  currentStreakDays      Int      @default(0)
+  longestStreakDays      Int      @default(0)
+  lastFocusDate          DateTime?
+  totalSessions          Int      @default(0)
+  completedTasks         Int      @default(0)
+
+  tasks      Task[]
+  dailyStats FocusDailyStat[]
 }
 
 model Task {
@@ -39,6 +49,10 @@ model Task {
   status      TaskStatus @default(PENDING)
   dueDate     DateTime?
   createdAt   DateTime   @default(now())
+  completedAt DateTime?
+
+  focusDurationSeconds      Int @default(0)
+  distractionDurationSeconds Int @default(0)
 
   user   User   @relation(fields: [userId], references: [id])
   userId Int
@@ -53,7 +67,24 @@ model FocusSession {
   durationSeconds Int
   status          FocusSessionStatus @default(PLANNED)
   createdAt       DateTime           @default(now())
+  focusDurationSeconds      Int                @default(0)
+  distractionDurationSeconds Int                @default(0)
+  interruptionCount         Int                @default(0)
 
   task   Task @relation(fields: [taskId], references: [id])
   taskId Int
+}
+
+model FocusDailyStat {
+  id                        Int      @id @default(autoincrement())
+  date                      DateTime
+  focusDurationSeconds      Int      @default(0)
+  distractionDurationSeconds Int      @default(0)
+  sessionCount              Int      @default(0)
+  createdAt                 DateTime @default(now())
+
+  user   User @relation(fields: [userId], references: [id])
+  userId Int
+
+  @@unique([userId, date])
 }

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -5,6 +5,9 @@ const prisma = new PrismaClient();
 
 async function main() {
   const passwordHash = await bcrypt.hash('password123', 10);
+  const today = new Date();
+  const startOfToday = new Date(today);
+  startOfToday.setHours(0, 0, 0, 0);
 
   const user = await prisma.user.upsert({
     where: { email: 'demo@antyo.focus' },
@@ -13,6 +16,14 @@ async function main() {
       email: 'demo@antyo.focus',
       name: 'Demo User',
       passwordHash,
+      totalFocusSeconds: 22 * 60,
+      totalDistractedSeconds: 3 * 60,
+      weeklyFocusSeconds: 22 * 60,
+      currentStreakDays: 1,
+      longestStreakDays: 1,
+      lastFocusDate: startOfToday,
+      totalSessions: 1,
+      completedTasks: 0,
     },
   });
 
@@ -24,6 +35,8 @@ async function main() {
       description: 'Install dependencies and review onboarding docs.',
       status: TaskStatus.IN_PROGRESS,
       dueDate: new Date(Date.now() + 72 * 60 * 60 * 1000),
+      focusDurationSeconds: 22 * 60,
+      distractionDurationSeconds: 3 * 60,
       user: { connect: { id: user.id } },
     },
   });
@@ -48,6 +61,9 @@ async function main() {
       endTime: new Date(Date.now() + 25 * 60 * 1000),
       durationSeconds: 25 * 60,
       status: FocusSessionStatus.COMPLETED,
+      focusDurationSeconds: 22 * 60,
+      distractionDurationSeconds: 3 * 60,
+      interruptionCount: 1,
       task: { connect: { id: taskOne.id } },
     },
   });
@@ -59,7 +75,27 @@ async function main() {
       startTime: new Date(Date.now() + 60 * 60 * 1000),
       durationSeconds: 50 * 60,
       status: FocusSessionStatus.PLANNED,
+      focusDurationSeconds: 0,
+      distractionDurationSeconds: 0,
+      interruptionCount: 0,
       task: { connect: { id: taskTwo.id } },
+    },
+  });
+
+  await prisma.focusDailyStat.upsert({
+    where: {
+      userId_date: {
+        userId: user.id,
+        date: startOfToday,
+      },
+    },
+    update: {},
+    create: {
+      date: startOfToday,
+      focusDurationSeconds: 22 * 60,
+      distractionDurationSeconds: 3 * 60,
+      sessionCount: 1,
+      user: { connect: { id: user.id } },
     },
   });
 }


### PR DESCRIPTION
## Summary
- extend Prisma models with dashboard-oriented aggregates for users, tasks, and focus sessions
- add daily focus statistics model and migration to persist per-day aggregates
- update seed data to populate new statistic fields for the demo user

## Testing
- not run (npm registry access for Prisma CLI unavailable in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fde9af6a4832eb8c4a4a53d9fd729)