### PR TITLE
Add backend deployment assets and CI workflow

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,48 @@
+name: Backend CI
+
+on:
+  push:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    env:
+      DATABASE_URL: "file:./prisma/ci.db"
+      JWT_SECRET: "ci-secret-key"
+      JWT_EXPIRES_IN: "1d"
+      LOG_LEVEL: "info"
+      PORT: 3001
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Generate Prisma client and apply migrations
+        run: |
+          npx prisma generate
+          npx prisma migrate deploy
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.env
+.env.*
+.git
+coverage
+**/*.log

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+COPY package.json ./
+COPY prisma ./prisma
+
+RUN npm install
+RUN npx prisma generate
+
+COPY src ./src
+
+ENV NODE_ENV=production
+RUN npm prune --production
+
+FROM node:20-alpine
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/src ./src
+
+EXPOSE 3001
+CMD ["node", "src/index.js"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -91,6 +91,44 @@ Once running, the API is available at `http://localhost:3001/api`.
   npm test
   ```
 
+## Deploy
+
+### Build a production image
+1. Ensure a `.env` file exists with production-ready values.
+2. Build and run the Docker image from the `backend` folder:
+   ```bash
+   docker build -t antyo-focus-backend .
+   docker run -p 3001:3001 --env-file .env antyo-focus-backend
+   ```
+
+The Dockerfile uses a multi-stage build to generate the Prisma client and prune development dependencies before shipping the runtime image.
+
+### Render
+1. Create a new **Web Service** from this repository and point it to the `backend` directory.
+2. Set the environment variables from `.env.example` (for SQLite, keep `DATABASE_URL="file:./prisma/dev.db"`).
+3. Use the following commands:
+   - **Build command:** `npm install && npx prisma generate`
+   - **Start command:** `node src/index.js`
+4. Add a **Post-deploy command** to apply migrations: `npx prisma migrate deploy`.
+
+### Railway
+1. Create a new **Service** and deploy the `backend` folder.
+2. Configure `DATABASE_URL`, `JWT_SECRET`, and other values from `.env.example` as Railway variables.
+3. Set the **Start Command** to `node src/index.js` and add a **Deploy hook** command `npx prisma migrate deploy` to keep the schema up-to-date.
+
+### Heroku
+1. Create a Heroku app and add the repository as a deployment source.
+2. Set config vars for all entries in `.env.example`; if using SQLite, set `DATABASE_URL` to a writable path such as `file:./prisma/dev.db`.
+3. Define the **Buildpack** as `heroku/nodejs` (or use the default Node detection).
+4. Add a **release phase** command to run migrations automatically:
+   ```bash
+   npx prisma migrate deploy
+   ```
+5. Set the **Procfile** (or Heroku "Command") to start the API:
+   ```bash
+   web: node src/index.js
+   ```
+
 ## Healthcheck
 A healthcheck route is available at `GET /api/health` and returns a simple status payload.
 


### PR DESCRIPTION
## Summary
- add Dockerfile and .dockerignore to produce a production-ready backend image with Prisma generation
- create a GitHub Actions workflow to install dependencies, run migrations, lint, and test the backend
- document deployment steps for Docker plus Render, Railway, and Heroku

## Testing
- `npm install --package-lock-only` *(fails with npm registry 403 in the environment; dependencies could not be installed to run tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fe1e5ff7c832e81326fa36bd6281b)