### PR TITLE
Add dashboard aggregation, pagination, and CORS support

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -121,6 +121,131 @@ components:
               $ref: '#/components/schemas/Task'
           required:
             - task
+    Pagination:
+      type: object
+      properties:
+        page:
+          type: integer
+          example: 1
+        pageSize:
+          type: integer
+          example: 10
+        total:
+          type: integer
+          example: 42
+      required:
+        - page
+        - pageSize
+        - total
+    DashboardDailyFocus:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+          example: 2024-09-12
+        focusDurationSeconds:
+          type: integer
+          example: 2700
+        distractionDurationSeconds:
+          type: integer
+          example: 300
+        sessionCount:
+          type: integer
+          example: 3
+      required:
+        - date
+        - focusDurationSeconds
+        - distractionDurationSeconds
+        - sessionCount
+    DashboardSummary:
+      type: object
+      properties:
+        tasks:
+          type: object
+          properties:
+            total:
+              type: integer
+              example: 12
+            byStatus:
+              type: object
+              additionalProperties:
+                type: integer
+            upcoming:
+              type: array
+              items:
+                $ref: '#/components/schemas/Task'
+          required:
+            - total
+            - byStatus
+            - upcoming
+        sessions:
+          type: object
+          properties:
+            total:
+              type: integer
+              example: 28
+            durationSeconds:
+              type: integer
+              example: 54000
+            byStatus:
+              type: object
+              additionalProperties:
+                type: integer
+            recent:
+              type: array
+              items:
+                $ref: '#/components/schemas/FocusSessionWithTask'
+          required:
+            - total
+            - durationSeconds
+            - byStatus
+            - recent
+        focus:
+          type: object
+          properties:
+            streak:
+              type: object
+              properties:
+                currentDays:
+                  type: integer
+                  example: 3
+                longestDays:
+                  type: integer
+                  example: 10
+                lastFocusDate:
+                  type: string
+                  format: date-time
+                  nullable: true
+                  example: 2024-09-12T00:00:00.000Z
+              required:
+                - currentDays
+                - longestDays
+                - lastFocusDate
+            totals:
+              type: object
+              properties:
+                lifetimeFocusSeconds:
+                  type: integer
+                  example: 120000
+                weeklyFocusSeconds:
+                  type: integer
+                  example: 18000
+              required:
+                - lifetimeFocusSeconds
+                - weeklyFocusSeconds
+            daily:
+              type: array
+              items:
+                $ref: '#/components/schemas/DashboardDailyFocus'
+          required:
+            - streak
+            - totals
+            - daily
+      required:
+        - tasks
+        - sessions
+        - focus
 paths:
   /auth/register:
     post:
@@ -208,6 +333,37 @@ paths:
       summary: List tasks for the authenticated user
       security:
         - bearerAuth: []
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+          description: Page number starting from 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 10
+          description: Number of tasks per page
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [PENDING, IN_PROGRESS, COMPLETED]
+          description: Filter tasks by status
+        - in: query
+          name: dueFrom
+          schema:
+            type: string
+            format: date
+          description: Include tasks with dueDate greater than or equal to this date
+        - in: query
+          name: dueTo
+          schema:
+            type: string
+            format: date
+          description: Include tasks with dueDate less than or equal to this date
       responses:
         '200':
           description: Tasks retrieved
@@ -220,8 +376,11 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Task'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
                 required:
                   - tasks
+                  - pagination
         '401':
           description: Missing or invalid JWT
   /sessions:
@@ -229,6 +388,42 @@ paths:
       summary: List focus sessions for the authenticated user
       security:
         - bearerAuth: []
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+          description: Page number starting from 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 10
+          description: Number of sessions per page
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [PLANNED, ACTIVE, COMPLETED]
+          description: Filter sessions by status
+        - in: query
+          name: taskId
+          schema:
+            type: integer
+          description: Filter sessions for a specific task
+        - in: query
+          name: startedFrom
+          schema:
+            type: string
+            format: date-time
+          description: Include sessions that started on or after this date
+        - in: query
+          name: startedTo
+          schema:
+            type: string
+            format: date-time
+          description: Include sessions that started on or before this date
       responses:
         '200':
           description: Sessions retrieved
@@ -241,7 +436,30 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/FocusSessionWithTask'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
                 required:
                   - sessions
+                  - pagination
+        '401':
+          description: Missing or invalid JWT
+  /dashboard:
+    get:
+      summary: Aggregated dashboard metrics for the authenticated user
+      description: Returns task counts, recent sessions, focus streak, and daily focus durations for the last 14 days.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Dashboard summary loaded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary:
+                    $ref: '#/components/schemas/DashboardSummary'
+                required:
+                  - summary
         '401':
           description: Missing or invalid JWT

--- a/backend/src/config/config.js
+++ b/backend/src/config/config.js
@@ -7,7 +7,8 @@ const config = {
   nodeEnv: process.env.NODE_ENV || 'development',
   jwtSecret: process.env.JWT_SECRET || 'dev-secret-key',
   jwtExpiresIn: process.env.JWT_EXPIRES_IN || '1d',
-  logLevel: process.env.LOG_LEVEL || 'info'
+  logLevel: process.env.LOG_LEVEL || 'info',
+  corsOrigin: process.env.CORS_ORIGIN || '*'
 };
 
 module.exports = config;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -3,9 +3,11 @@ const config = require('./config/config');
 const routes = require('./routes');
 const { logger, requestLoggerMiddleware } = require('./middleware/logger');
 const { notFoundHandler, errorHandler } = require('./middleware/errorHandler');
+const corsMiddleware = require('./middleware/cors');
 
 const app = express();
 
+app.use(corsMiddleware);
 app.use(express.json());
 app.use(requestLoggerMiddleware);
 app.use('/api', routes);

--- a/backend/src/middleware/cors.js
+++ b/backend/src/middleware/cors.js
@@ -1,0 +1,15 @@
+const config = require('../config/config');
+
+const corsMiddleware = (req, res, next) => {
+  res.header('Access-Control-Allow-Origin', config.corsOrigin);
+  res.header('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
+  res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+  if (req.method === 'OPTIONS') {
+    return res.sendStatus(204);
+  }
+
+  return next();
+};
+
+module.exports = corsMiddleware;

--- a/backend/src/repositories/focusSessionRepository.js
+++ b/backend/src/repositories/focusSessionRepository.js
@@ -1,11 +1,39 @@
 const prisma = require('../config/db');
 
-const findSessionsByUserId = async (userId) =>
-  prisma.focusSession.findMany({
-    where: { task: { userId } },
-    include: { task: true },
-    orderBy: { startTime: 'desc' },
-  });
+const findSessionsByUserId = async ({ userId, filters = {}, pagination }) => {
+  const where = { task: { userId } };
+
+  if (filters.status) {
+    where.status = filters.status;
+  }
+
+  if (filters.taskId) {
+    where.taskId = filters.taskId;
+  }
+
+  if (filters.startedFrom || filters.startedTo) {
+    where.startTime = {};
+    if (filters.startedFrom) {
+      where.startTime.gte = filters.startedFrom;
+    }
+    if (filters.startedTo) {
+      where.startTime.lte = filters.startedTo;
+    }
+  }
+
+  const [sessions, total] = await Promise.all([
+    prisma.focusSession.findMany({
+      where,
+      include: { task: true },
+      orderBy: { startTime: 'desc' },
+      skip: (pagination.page - 1) * pagination.pageSize,
+      take: pagination.pageSize,
+    }),
+    prisma.focusSession.count({ where }),
+  ]);
+
+  return { sessions, total };
+};
 
 const findSessionByIdForUser = async (sessionId, userId) =>
   prisma.focusSession.findFirst({

--- a/backend/src/services/dashboardService.js
+++ b/backend/src/services/dashboardService.js
@@ -7,38 +7,93 @@ const buildStatusCounts = (groups, statuses) =>
     return { ...acc, [status]: match ? match._count._all : 0 };
   }, {});
 
+const DAYS_OF_HISTORY = 14;
+
+const buildDateKey = (date) => new Date(date).toISOString().split('T')[0];
+
+const buildDailySeries = (startDate, endDate, dailyStats) => {
+  const statsByDate = dailyStats.reduce((acc, stat) => {
+    acc.set(buildDateKey(stat.date), stat);
+    return acc;
+  }, new Map());
+
+  const results = [];
+  for (
+    const cursor = new Date(startDate);
+    cursor <= endDate;
+    cursor.setDate(cursor.getDate() + 1)
+  ) {
+    const key = buildDateKey(cursor);
+    const stat = statsByDate.get(key);
+    results.push({
+      date: key,
+      focusDurationSeconds: stat?.focusDurationSeconds || 0,
+      distractionDurationSeconds: stat?.distractionDurationSeconds || 0,
+      sessionCount: stat?.sessionCount || 0,
+    });
+  }
+
+  return results;
+};
+
 const getDashboardSummary = async (userId) => {
-  const [taskGroups, sessionGroups, sessionDurationAgg, recentSessions, upcomingTasks] =
-    await Promise.all([
-      prisma.task.groupBy({
-        by: ['status'],
-        _count: { _all: true },
-        where: { userId },
-      }),
-      prisma.focusSession.groupBy({
-        by: ['status'],
-        _count: { _all: true },
-        where: { task: { userId } },
-      }),
-      prisma.focusSession.aggregate({
-        where: { task: { userId } },
-        _sum: { durationSeconds: true },
-      }),
-      prisma.focusSession.findMany({
-        where: { task: { userId } },
-        include: { task: true },
-        orderBy: { startTime: 'desc' },
-        take: 5,
-      }),
-      prisma.task.findMany({
-        where: {
-          userId,
-          status: { not: TaskStatus.COMPLETED },
-        },
-        orderBy: [{ dueDate: 'asc' }, { createdAt: 'asc' }],
-        take: 5,
-      }),
-    ]);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const startDate = new Date(today);
+  startDate.setDate(today.getDate() - (DAYS_OF_HISTORY - 1));
+
+  const [
+    taskGroups,
+    sessionGroups,
+    sessionDurationAgg,
+    recentSessions,
+    upcomingTasks,
+    dailyStats,
+    user,
+  ] = await Promise.all([
+    prisma.task.groupBy({
+      by: ['status'],
+      _count: { _all: true },
+      where: { userId },
+    }),
+    prisma.focusSession.groupBy({
+      by: ['status'],
+      _count: { _all: true },
+      where: { task: { userId } },
+    }),
+    prisma.focusSession.aggregate({
+      where: { task: { userId } },
+      _sum: { durationSeconds: true },
+    }),
+    prisma.focusSession.findMany({
+      where: { task: { userId } },
+      include: { task: true },
+      orderBy: { startTime: 'desc' },
+      take: 5,
+    }),
+    prisma.task.findMany({
+      where: {
+        userId,
+        status: { not: TaskStatus.COMPLETED },
+      },
+      orderBy: [{ dueDate: 'asc' }, { createdAt: 'asc' }],
+      take: 5,
+    }),
+    prisma.focusDailyStat.findMany({
+      where: { userId, date: { gte: startDate } },
+      orderBy: { date: 'asc' },
+    }),
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        currentStreakDays: true,
+        longestStreakDays: true,
+        lastFocusDate: true,
+        totalFocusSeconds: true,
+        weeklyFocusSeconds: true,
+      },
+    }),
+  ]);
 
   const taskStatusCounts = buildStatusCounts(taskGroups, Object.values(TaskStatus));
   const sessionStatusCounts = buildStatusCounts(sessionGroups, Object.values(FocusSessionStatus));
@@ -57,6 +112,18 @@ const getDashboardSummary = async (userId) => {
       durationSeconds: sessionDurationAgg._sum.durationSeconds || 0,
       byStatus: sessionStatusCounts,
       recent: recentSessions,
+    },
+    focus: {
+      streak: {
+        currentDays: user?.currentStreakDays || 0,
+        longestDays: user?.longestStreakDays || 0,
+        lastFocusDate: user?.lastFocusDate || null,
+      },
+      totals: {
+        lifetimeFocusSeconds: user?.totalFocusSeconds || 0,
+        weeklyFocusSeconds: user?.weeklyFocusSeconds || 0,
+      },
+      daily: buildDailySeries(startDate, today, dailyStats),
     },
   };
 };

--- a/backend/src/services/focusSessionService.js
+++ b/backend/src/services/focusSessionService.js
@@ -2,7 +2,8 @@ const { FocusSessionStatus, TaskStatus } = require('../utils/prisma');
 const focusSessionRepository = require('../repositories/focusSessionRepository');
 const taskRepository = require('../repositories/taskRepository');
 
-const getSessionsForUser = async (userId) => focusSessionRepository.findSessionsByUserId(userId);
+const getSessionsForUser = async ({ userId, filters, pagination }) =>
+  focusSessionRepository.findSessionsByUserId({ userId, filters, pagination });
 
 const startSession = async ({ userId, taskId, targetDurationSeconds }) => {
   const task = await taskRepository.findTaskByIdForUser(taskId, userId);

--- a/backend/src/services/taskService.js
+++ b/backend/src/services/taskService.js
@@ -1,7 +1,8 @@
 const { TaskStatus } = require('../utils/prisma');
 const taskRepository = require('../repositories/taskRepository');
 
-const getTasksForUser = async (userId) => taskRepository.findTasksByUserId(userId);
+const getTasksForUser = async ({ userId, filters, pagination }) =>
+  taskRepository.findTasksByUserId({ userId, filters, pagination });
 
 const getTaskByIdForUser = async (taskId, userId) => taskRepository.findTaskByIdForUser(taskId, userId);
 


### PR DESCRIPTION
## Summary
- enable configurable CORS middleware on the API server
- add pagination and filtering support for task and focus session listing endpoints
- expand the dashboard summary with streak/daily focus metrics and document the new endpoints in OpenAPI

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fe33a784c832eb6ac45b57ea8abfe)